### PR TITLE
Use getSession's status within auth and account layouts to render/re-direct

### DIFF
--- a/src/layouts/AccountLayout.js
+++ b/src/layouts/AccountLayout.js
@@ -10,16 +10,17 @@ import menu from '@/config/menu/index';
 import { useWorkspace } from '@/providers/workspace';
 
 const AccountLayout = ({ children }) => {
-  const { data } = useSession();
+  const { status } = useSession();
   const router = useRouter();
   const { workspace } = useWorkspace();
 
   useEffect(() => {
-    if (!data) {
+    if (status === 'unauthenticated') {
       router.replace('/auth/login');
     }
-  }, [data, router]);
+  }, [status, router]);
 
+  if (status === 'loading') return <></>;
   return (
     <main className="relative flex flex-col w-screen h-screen space-x-0 text-gray-800 dark:text-gray-200 md:space-x-5 md:flex-row bg-gray-50 dark:bg-gray-800">
       <Sidebar menu={menu(workspace?.slug)} />

--- a/src/layouts/AuthLayout.js
+++ b/src/layouts/AuthLayout.js
@@ -6,17 +6,18 @@ import { Toaster } from 'react-hot-toast';
 
 const AuthLayout = ({ children }) => {
   const router = useRouter();
-  const { data } = useSession();
+  const { status } = useSession();
   const { setTheme } = useTheme();
 
   useEffect(() => {
     setTheme('light');
 
-    if (data) {
+    if (status === 'authenticated') {
       router.push('/account');
     }
-  }, [data, router]);
+  }, [status, router]);
 
+  if (status === 'loading') return <></>;
   return (
     <main className="relative flex flex-col items-center justify-center h-screen p-10 space-y-10">
       <Toaster position="bottom-center" toastOptions={{ duration: 10000 }} />


### PR DESCRIPTION
If we visit the settings page https://demo.nextacular.co/account/settings and hit refresh/reload, we end up on the https://demo.nextacular.co/account page. This happens because on the first render of the [AccountLayout](https://github.com/nextacular/nextacular/blob/main/src/layouts/AccountLayout.js#L19), the `getSession()`'s data object is not ready and the user gets incorrectly re-directed to `/auth/login`. Within the [AuthLayout](https://github.com/nextacular/nextacular/blob/main/src/layouts/AuthLayout.js#L16), the `getSession()->data` is checked again, it is found to be valid and then the user is re-directed to `https://demo.nextacular.co/account/`.

This pull-request attempts to fix the issue by waiting until getSession returns a valid data and this is checked using the status object returned by getSession() instead of the data object. This also fixes #28 and #20 

**Please note**: Since there are no existing test cases, I couldn't test these changes on the nextacular demo site but I did test it out on the code base for my personal project. I would be happy to revise the changes if required.