### PR TITLE
remove #https comment from .env.sample

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,4 +1,4 @@
-APP_URL = http://localhost:3000 # https
+APP_URL = http://localhost:3000
 # NEXTAUTH_SECRET = NArBDTMHof0EGTx66MFpwk3KRHMNTeUfxvLhbYv14eY= # Generate using `openssl rand -base64 32` – Optional environment variable
 
 # Database Configuration


### PR DESCRIPTION
Because this stops the steps in https://docs.nextacular.co/getting-started/quick-start and you get a weird error that is hard to diagnose. But it is because .env file cannot have comments at the end. At least on Windows!