### PR TITLE
auth requires getServerSession for api validation

### DIFF
--- a/src/lib/server/session-check.js
+++ b/src/lib/server/session-check.js
@@ -1,8 +1,9 @@
-import { getSession } from 'next-auth/react';
+import { getServerSession } from 'next-auth/next';
+import { authOptions } from '/src/pages/api/auth/[...nextauth]';
 
 const validateMiddleware = () => {
   return async (req, res, next) => {
-    const session = await getSession({ req });
+    const session = await getServerSession(req, res, authOptions);
     const errors = [];
 
     if (!session) {

--- a/src/pages/api/auth/[...nextauth].js
+++ b/src/pages/api/auth/[...nextauth].js
@@ -7,7 +7,7 @@ import { html, text } from '@/config/email-templates/signin';
 import { emailConfig, sendMail } from '@/lib/server/mail';
 import { createPaymentAccount, getPayment } from '@/prisma/services/customer';
 
-export default NextAuth({
+export const authOptions = {
   adapter: PrismaAdapter(prisma),
   callbacks: {
     session: async ({ session, user }) => {
@@ -52,4 +52,6 @@ export default NextAuth({
   session: {
     jwt: true,
   },
-});
+};
+
+export default NextAuth(authOptions);


### PR DESCRIPTION
Sign in worked correctly client-side, however all API calls had an empty session. This fixes it.